### PR TITLE
Fix admin session token handling

### DIFF
--- a/admin/api.js
+++ b/admin/api.js
@@ -46,7 +46,14 @@ class OpenAIAPI {
                 start_date: startDate,
                 end_date: endDate
             });
-            const response = await fetch(`/api/admin/openai-usage.php?${params}`);
+
+            const options = {};
+            const authToken = sessionStorage.getItem('admin_auth_token');
+            if (authToken) {
+                options.headers = { 'Authorization': `Bearer ${authToken}` };
+            }
+
+            const response = await fetch(`/api/admin/openai-usage.php?${params}`, options);
             
             const responseData = await response.json();
             

--- a/admin/test-backend.html
+++ b/admin/test-backend.html
@@ -269,9 +269,15 @@
             log(`📊 Test API Usage pour la période ${startDate} → ${endDate}`);
 
             try {
+                const headers = { 'Content-Type': 'application/json' };
+                const authToken = sessionStorage.getItem('admin_auth_token');
+                if (authToken) {
+                    headers['Authorization'] = `Bearer ${authToken}`;
+                }
+
                 const response = await fetch('/api/admin/openai-usage.php', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers,
                     body: JSON.stringify({
                         start_date: startDate,
                         end_date: endDate
@@ -316,9 +322,17 @@
                 
                 for (const test of tests) {
                     try {
+                        const headers = { 'Content-Type': 'application/json' };
+                        if (test.url.includes('openai-usage.php')) {
+                            const authToken = sessionStorage.getItem('admin_auth_token');
+                            if (authToken) {
+                                headers['Authorization'] = `Bearer ${authToken}`;
+                            }
+                        }
+
                         const response = await fetch(test.url, {
                             method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
+                            headers,
                             body: JSON.stringify({})
                         });
                         


### PR DESCRIPTION
## Summary
- fix admin console session handling
- include Authorization header in backend test pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e6edf0dfc8325864a69f98ec626b1